### PR TITLE
chore(renovate): update yarn package name for v2+ upgrade

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -100,7 +100,7 @@ RUN install-tool bazelisk v1.19.0
 # renovate: datasource=npm
 RUN install-tool pnpm 9.0.5
 
-# renovate: datasource=npm
+# renovate: datasource=npm packageName=@yarnpkg/cli-dist
 RUN install-tool yarn 1.22.22
 
 # --------------------------------------


### PR DESCRIPTION
With #421 we can support yarn v2+. I think we agreed to set yarn v4 as default on full image from renovate v38.