### PR TITLE
docs: link to Renovate Docker images in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # Renovate base-image
 
-This repository is used as a base image for renovatebot/renovate docker images.
+This repository is the base image for our [`renovatebot/renovate` Docker images](https://hub.docker.com/r/renovate/renovate).


### PR DESCRIPTION
## Changes:

- Rewrite sentence a bit
- Link to the `renovatebot/renovate` Docker image on Docker Hub
- Capitalize the proper noun Docker

## Context:

Drive by contribution. 😄 