### PR TITLE
chore(renovate): use `containerbase/nix-prebuild` as datasource

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -108,7 +108,7 @@ RUN install-tool jb v0.6.0
 RUN install-tool bun 1.1.34
 
 
-# renovate: datasource=github-tags packageName=NixOS/nix
+# renovate: datasource=github-releases packageName=containerbase/nix-prebuild
 RUN install-tool nix 2.24.10
 
 


### PR DESCRIPTION
- See #1263 