### PR TITLE
build: use channel for computing docker tags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,14 +67,6 @@ jobs:
         with:
           apt-proxy: true
 
-      - name: build image
-        run: docker buildx bake
-
-      - name: Docker registry login
-        if: inputs.cache
-        run: |
-          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.repository_owner }} --password-stdin
-
       - name: compute channel
         if: inputs.cache
         run: |
@@ -84,6 +76,14 @@ jobs:
             local ref="${{github.ref_name}}"
             echo "CHANNEL=${ref:6}" >> "$GITHUB_ENV"
           fi
+
+      - name: build image
+        run: docker buildx bake
+
+      - name: Docker registry login
+        if: inputs.cache
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.repository_owner }} --password-stdin
 
       - name: cache images
         if: inputs.cache

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,6 +75,16 @@ jobs:
         run: |
           echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.repository_owner }} --password-stdin
 
+      - name: compute channel
+        if: inputs.cache
+        run: |
+          if [[ "${{github.ref_name}}" == "next" ]]
+            echo "CHANNEL=${{github.ref_name}}" >> "$GITHUB_ENV"
+          elif [[ "${{startsWith(github.ref_name, 'maint/')}}" == "true" ]]
+            local ref="${{github.ref_name}}"
+            echo "CHANNEL=${ref:6}" >> "$GITHUB_ENV"
+          fi
+
       - name: cache images
         if: inputs.cache
         run: docker buildx bake build-cache

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -13,8 +13,8 @@
     [
       "@semantic-release/exec",
       {
-        "prepareCmd": "pnpm release:prepare --release=${nextRelease.version} --sha=${nextRelease.gitHead}",
-        "publishCmd": "pnpm release:publish --release=${nextRelease.version} --sha=${nextRelease.gitHead}"
+        "prepareCmd": "pnpm release:prepare --release=${nextRelease.version} --channel='${branch.channel ?? ''}' --sha=${nextRelease.gitHead}",
+        "publishCmd": "pnpm release:publish --release=${nextRelease.version} --channel='${branch.channel ?? ''}' --sha=${nextRelease.gitHead}"
       }
     ]
   ],

--- a/tools/prepare-release.js
+++ b/tools/prepare-release.js
@@ -3,15 +3,16 @@ import shell from 'shelljs';
 
 class PrepareCommand extends Command {
   release = Option.String('-r,--release', { required: true });
+  channel = Option.String('-c,--channel', { required: true });
   gitSha = Option.String('--sha');
   dryRun = Option.Boolean('-d,--dry-run');
 
   async execute() {
     /** @type {shell.ShellString} */
     let r;
-    const { release, gitSha, dryRun } = this;
+    const { release, gitSha, dryRun, channel } = this;
 
-    shell.echo(`Preparing version: ${release} (${gitSha})`);
+    shell.echo(`Preparing version: ${release} (${gitSha}, ${channel})`);
 
     if (dryRun) {
       shell.echo('DRY-RUN: done.');
@@ -20,6 +21,10 @@ class PrepareCommand extends Command {
 
     process.env.TAG = release;
     process.env.BASE_IMAGE_VERSION = release;
+
+    if (channel) {
+      process.env.CHANNEL = channel;
+    }
 
     shell.echo('Building images...');
     r = shell.exec(

--- a/tools/publish-release.js
+++ b/tools/publish-release.js
@@ -3,17 +3,22 @@ import shell from 'shelljs';
 
 class ReleaseCommand extends Command {
   release = Option.String('-r,--release', { required: true });
+  channel = Option.String('-c,--channel', { required: true });
   gitSha = Option.String('--sha');
   dryRun = Option.Boolean('-d,--dry-run');
 
   async execute() {
     /** @type {shell.ShellString} */
     let r;
-    const { release, gitSha, dryRun } = this;
+    const { release, gitSha, dryRun, channel } = this;
 
-    shell.echo(`Publish version: ${release} (${gitSha})`);
+    shell.echo(`Publish version: ${release} (${gitSha}, ${channel})`);
     process.env.TAG = release;
     process.env.BASE_IMAGE_VERSION = release;
+
+    if (channel) {
+      process.env.CHANNEL = channel;
+    }
 
     if (dryRun) {
       shell.echo('DRY-RUN: done.');


### PR DESCRIPTION
so we no longer push latest tag on maintenance or next branches