### PR TITLE
chore(renovate): stop publish v9 and add v10

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,7 +4,7 @@
     "github>renovatebot/.github",
     "github>renovatebot/.github//merge-queue.json"
   ],
-  "baseBranchPatterns": ["$default", "next", "maint/9.x"],
+  "baseBranchPatterns": ["$default", "next", "maint/10.x"],
   "packageRules": [
     {
       "description": "Use `ci` semantic commit scope for ci deps",


### PR DESCRIPTION
Stop updating v9 maintenance branch and add v10 maintenance branch.

v9 isn't used any longer by renovate since v41 and v42 will get v11 which is now main branch