### PR TITLE
build: add workaround for latest github release from maintenance branch

### DIFF
--- a/patches/@semantic-release__github.patch
+++ b/patches/@semantic-release__github.patch
@@ -1,0 +1,12 @@
+diff --git a/lib/publish.js b/lib/publish.js
+index b91c39d1fd1f3c251eb3b1b29200921086437f90..57bbad107d6161b22e9392e4c359863a3ec1a679 100644
+--- a/lib/publish.js
++++ b/lib/publish.js
+@@ -52,6 +52,7 @@ export default async function publish(pluginConfig, context, { Octokit }) {
+     name: template(releaseNameTemplate)(context),
+     body: template(releaseBodyTemplate)(context),
+     prerelease: isPrerelease(branch),
++    make_latest: "legacy",
+   };
+ 
+   debug("release object: %O", release);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  '@semantic-release/github':
+    hash: aae590bd289770196ad237250a80b6b0b583526b3a0c6056497dd80561d798d3
+    path: patches/@semantic-release__github.patch
+
 importers:
 
   .:
@@ -1662,7 +1667,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@semantic-release/github@11.0.4(semantic-release@24.2.7)':
+  '@semantic-release/github@11.0.4(patch_hash=aae590bd289770196ad237250a80b6b0b583526b3a0c6056497dd80561d798d3)(semantic-release@24.2.7)':
     dependencies:
       '@octokit/core': 7.0.3
       '@octokit/plugin-paginate-rest': 13.1.1(@octokit/core@7.0.3)
@@ -2607,7 +2612,7 @@ snapshots:
     dependencies:
       '@semantic-release/commit-analyzer': 13.0.1(semantic-release@24.2.7)
       '@semantic-release/error': 4.0.0
-      '@semantic-release/github': 11.0.4(semantic-release@24.2.7)
+      '@semantic-release/github': 11.0.4(patch_hash=aae590bd289770196ad237250a80b6b0b583526b3a0c6056497dd80561d798d3)(semantic-release@24.2.7)
       '@semantic-release/npm': 12.0.2(semantic-release@24.2.7)
       '@semantic-release/release-notes-generator': 14.0.3(semantic-release@24.2.7)
       aggregate-error: 5.0.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+patchedDependencies:
+  '@semantic-release/github': patches/@semantic-release__github.patch


### PR DESCRIPTION
backport from
- #2108

(cherry picked from commit dbec2181702e02d1f2fcff9f1e5de4f8386a8d63)