### PR TITLE
build: fix workaround for latest github release from maintenance branch

### DIFF
--- a/patches/@semantic-release__github.patch
+++ b/patches/@semantic-release__github.patch
@@ -1,12 +1,12 @@
 diff --git a/lib/publish.js b/lib/publish.js
-index b91c39d1fd1f3c251eb3b1b29200921086437f90..57bbad107d6161b22e9392e4c359863a3ec1a679 100644
+index b91c39d1fd1f3c251eb3b1b29200921086437f90..abcc5716de218426494123c2d33c03c463ace8e8 100644
 --- a/lib/publish.js
 +++ b/lib/publish.js
 @@ -52,6 +52,7 @@ export default async function publish(pluginConfig, context, { Octokit }) {
      name: template(releaseNameTemplate)(context),
      body: template(releaseBodyTemplate)(context),
      prerelease: isPrerelease(branch),
-+    make_latest: "legacy",
++    make_latest: branch.type === "release" && branch.main && !branch.prerelease,
    };
  
    debug("release object: %O", release);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,7 +6,7 @@ settings:
 
 patchedDependencies:
   '@semantic-release/github':
-    hash: aae590bd289770196ad237250a80b6b0b583526b3a0c6056497dd80561d798d3
+    hash: 330f41f7c54b3e3d3cd2dd145cbe9afab8290a7b6f92b9e67fef6fe75ca3b80c
     path: patches/@semantic-release__github.patch
 
 importers:
@@ -1668,7 +1668,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@semantic-release/github@11.0.4(patch_hash=aae590bd289770196ad237250a80b6b0b583526b3a0c6056497dd80561d798d3)(semantic-release@24.2.7)':
+  '@semantic-release/github@11.0.4(patch_hash=330f41f7c54b3e3d3cd2dd145cbe9afab8290a7b6f92b9e67fef6fe75ca3b80c)(semantic-release@24.2.7)':
     dependencies:
       '@octokit/core': 7.0.3
       '@octokit/plugin-paginate-rest': 13.1.1(@octokit/core@7.0.3)
@@ -2613,7 +2613,7 @@ snapshots:
     dependencies:
       '@semantic-release/commit-analyzer': 13.0.1(semantic-release@24.2.7)
       '@semantic-release/error': 4.0.0
-      '@semantic-release/github': 11.0.4(patch_hash=aae590bd289770196ad237250a80b6b0b583526b3a0c6056497dd80561d798d3)(semantic-release@24.2.7)
+      '@semantic-release/github': 11.0.4(patch_hash=330f41f7c54b3e3d3cd2dd145cbe9afab8290a7b6f92b9e67fef6fe75ca3b80c)(semantic-release@24.2.7)
       '@semantic-release/npm': 12.0.2(semantic-release@24.2.7)
       '@semantic-release/release-notes-generator': 14.0.3(semantic-release@24.2.7)
       aggregate-error: 5.0.0


### PR DESCRIPTION
the previous workaround doesn work as expected