### PR TITLE
feat(deps): add mise to -full

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -143,6 +143,9 @@ RUN install-tool flutter 3.44.4
 # renovate: datasource=github-releases packageName=carvel-dev/vendir
 RUN install-tool vendir v0.46.0
 
+# renovate: datasource=github-releases packageName=jdx/mise
+RUN install-tool mise v2026.6.14
+
 # --------------------------------------
 # final image
 # --------------------------------------


### PR DESCRIPTION
Per [0], for users of `binarySource=global`, the newly introduced mise
lockfile support cannot invoke `mise`.

[0]: https://github.com/renovatebot/renovate/discussions/43882

Co-authored-by: Claude Sonnet 4.6 <jamie.tanna+claude-code@mend.io>
