### PR TITLE
feat!: remove `docker`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,10 +12,6 @@ LABEL org.opencontainers.image.source="https://github.com/renovatebot/base-image
   org.opencontainers.image.url="https://renovatebot.com" \
   org.opencontainers.image.licenses="MIT"
 
-
-# renovate: datasource=github-releases packageName=moby/moby
-RUN install-tool docker v28.5.2
-
 # --------------------------------------
 # slim image
 # --------------------------------------


### PR DESCRIPTION
As part of Renovate 43, we made `binarySource=docker` more clearly
deprecated.

As part of Renovate 44, we are removing the default installation of
`docker` in our base image.

Users will still be able to use `binarySource=docker` by installing
`docker` themselves manually.
